### PR TITLE
feat: add EXCLUDE_FORKS option to skip forked repos

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
         EXCLUDE_REPOS: ${{ secrets.EXCLUDE_REPOS }}
         EXCLUDE_LANGS: ${{ secrets.EXCLUDE_LANGS }}
         EXCLUDE_PRIVATE: "false"
+        EXCLUDE_FORKS: "true"
         DEBUG: "false"
         # TODO: Remove this when they get their API working again
         # https://github.com/orgs/community/discussions/192970

--- a/src/main.zig
+++ b/src/main.zig
@@ -45,6 +45,7 @@ const Args = struct {
     exclude_repos: ?[]const u8 = null,
     exclude_langs: ?[]const u8 = null,
     exclude_private: bool = false,
+    exclude_forks: bool = false,
     overview_output_file: ?[]const u8 = null,
     languages_output_file: ?[]const u8 = null,
     overview_template: ?[]const u8 = null,
@@ -269,7 +270,8 @@ pub fn main() !void {
     defer aggregate_stats.language_colors.deinit();
     for (stats.repositories) |repository| {
         if (glob.matchAny(exclude_repos orelse &.{}, repository.name) or
-            (args.exclude_private and repository.private))
+            (args.exclude_private and repository.private) or
+            (args.exclude_forks and repository.is_fork))
         {
             continue;
         }

--- a/src/statistics.zig
+++ b/src/statistics.zig
@@ -22,6 +22,7 @@ const Repository = struct {
     lines_changed: u32,
     views: u32,
     private: bool,
+    is_fork: bool,
 
     pub fn deinit(self: @This(), allocator: std.mem.Allocator) void {
         allocator.free(self.name);
@@ -254,6 +255,7 @@ fn getReposByYear(
         \\          stargazerCount
         \\          forkCount
         \\          isPrivate
+        \\          isFork
         \\          languages(
         \\              first: 100,
         \\              orderBy: { direction: DESC, field: SIZE }
@@ -310,6 +312,7 @@ fn getReposByYear(
                         stargazerCount: u32,
                         forkCount: u32,
                         isPrivate: bool,
+                        isFork: bool,
                         languages: ?struct {
                             edges: ?[]struct {
                                 size: u32,
@@ -382,6 +385,7 @@ fn getReposByYear(
             .stars = raw_repo.stargazerCount,
             .forks = raw_repo.forkCount,
             .private = raw_repo.isPrivate,
+            .is_fork = raw_repo.isFork,
             .languages = null,
             .views = 0,
             .lines_changed = 0,


### PR DESCRIPTION
## Summary
- Restores the pre-Zig-rewrite behavior (`EXCLUDE_FORKED_REPOS` in the old Python version) that dropped forked repos from the aggregate — now via `EXCLUDE_FORKS` for consistency with `EXCLUDE_REPOS`/`EXCLUDE_LANGS`/`EXCLUDE_PRIVATE`.
- Adds `isFork` to the `commitContributionsByRepository` GraphQL query.
- Adds `Repository.is_fork` + `Args.exclude_forks` and filters forks in the aggregation when the flag is set.
- Enables `EXCLUDE_FORKS: "true"` in the default workflow.

## Rationale
After the Zig rewrite, stars/forks are summed across every repo you've committed to — including OSS projects. For naxey this blew up stars from 21 → 129,869. Excluding forks doesn't fully fix that (you'd still count big OSS repos you contributed to directly), but it's the dominant source of inflation and matches the old behavior.

## Test plan
- [ ] Merge and let the scheduled workflow run (or trigger manually).
- [ ] Confirm the Stars/Forks numbers drop to a reasonable size.
- [ ] Confirm the generated `overview.svg` on the `generated` branch renders correctly.
- [ ] Consider upstreaming this to `jstrieb/github-stats` once it's verified to work.