### PR TITLE
feat: add OWNED_ONLY option to restrict stats to repos you own

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         EXCLUDE_LANGS: ${{ secrets.EXCLUDE_LANGS }}
         EXCLUDE_PRIVATE: "false"
         EXCLUDE_FORKS: "true"
+        OWNED_ONLY: "true"
         DEBUG: "false"
         # TODO: Remove this when they get their API working again
         # https://github.com/orgs/community/discussions/192970

--- a/src/main.zig
+++ b/src/main.zig
@@ -46,6 +46,7 @@ const Args = struct {
     exclude_langs: ?[]const u8 = null,
     exclude_private: bool = false,
     exclude_forks: bool = false,
+    owned_only: bool = false,
     overview_output_file: ?[]const u8 = null,
     languages_output_file: ?[]const u8 = null,
     overview_template: ?[]const u8 = null,
@@ -268,10 +269,16 @@ pub fn main() !void {
     };
     defer aggregate_stats.languages.deinit();
     defer aggregate_stats.language_colors.deinit();
+    const owner_prefix = if (args.owned_only)
+        try std.mem.concat(allocator, u8, &.{ stats.user, "/" })
+    else
+        &.{};
+    defer if (args.owned_only) allocator.free(owner_prefix);
     for (stats.repositories) |repository| {
         if (glob.matchAny(exclude_repos orelse &.{}, repository.name) or
             (args.exclude_private and repository.private) or
-            (args.exclude_forks and repository.is_fork))
+            (args.exclude_forks and repository.is_fork) or
+            (args.owned_only and !std.mem.startsWith(u8, repository.name, owner_prefix)))
         {
             continue;
         }


### PR DESCRIPTION
## Summary
`commitContributionsByRepository` returns every repo you've committed to, including canonical upstream OSS projects (Homebrew, nvim plugins, etc.). In the Zig rewrite these all contribute their `stargazerCount`/`forkCount` to your aggregate, blowing stars from 21 → 129,868 for this account. `EXCLUDE_FORKS` doesn't help because the inflation comes from canonical upstreams (where `isFork: false`), not your own forks.

This PR adds `OWNED_ONLY` that filters out any repository whose `nameWithOwner` prefix doesn't match the viewer's login — restoring the old pre-Zig-rewrite semantics of counting only repos you own.

- Adds `owned_only: bool` to `Args` (env: `OWNED_ONLY`, flag: `--owned-only`)
- Skips repos in aggregation whose prefix ≠ `{viewer}/`
- Enables `OWNED_ONLY: "true"` in the default workflow

## Test plan
- [ ] Merge and trigger the workflow; Stars should drop to a low two-digit number that matches this user's actual owned-repo star total.
- [ ] Lines of code changed should stay at current value (1.7M+) since the git fallback runs per-repo regardless.
- [ ] Language percentages should reflect only owned-repo language distribution.