### PR TITLE
chore: log per-repo include/skip decisions during aggregation

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -275,13 +275,34 @@ pub fn main() !void {
         &.{};
     defer if (args.owned_only) allocator.free(owner_prefix);
     for (stats.repositories) |repository| {
-        if (glob.matchAny(exclude_repos orelse &.{}, repository.name) or
-            (args.exclude_private and repository.private) or
-            (args.exclude_forks and repository.is_fork) or
-            (args.owned_only and !std.mem.startsWith(u8, repository.name, owner_prefix)))
-        {
+        const skip_reason: ?[]const u8 =
+            if (glob.matchAny(exclude_repos orelse &.{}, repository.name))
+                "EXCLUDE_REPOS"
+            else if (args.exclude_private and repository.private)
+                "EXCLUDE_PRIVATE"
+            else if (args.exclude_forks and repository.is_fork)
+                "EXCLUDE_FORKS"
+            else if (args.owned_only and
+                !std.mem.startsWith(u8, repository.name, owner_prefix))
+                "OWNED_ONLY"
+            else
+                null;
+        if (skip_reason) |reason| {
+            std.log.info(
+                "  skip  {s} (stars={d} forks={d}) — {s}",
+                .{ repository.name, repository.stars, repository.forks, reason },
+            );
             continue;
         }
+        std.log.info(
+            "include {s} (stars={d} forks={d} lines_changed={d})",
+            .{
+                repository.name,
+                repository.stars,
+                repository.forks,
+                repository.lines_changed,
+            },
+        );
         aggregate_stats.stars += repository.stars;
         aggregate_stats.forks += repository.forks;
         aggregate_stats.lines_changed += repository.lines_changed;


### PR DESCRIPTION
## Summary
Adds a one-liner log for each repo during aggregation so you can verify in the workflow log which repos contribute which stars/forks/lines and which filter (if any) rejected them.

Example output:
```
include naxey/homie-app (stars=3 forks=0 lines_changed=124567)
  skip  facebook/react-native (stars=126000 forks=25200) — OWNED_ONLY
  skip  knadh/listmonk (stars=19600 forks=2000) — OWNED_ONLY
```

Filter reasons: `EXCLUDE_REPOS`, `EXCLUDE_PRIVATE`, `EXCLUDE_FORKS`, `OWNED_ONLY`. Logs at INFO level, so they show up without enabling `DEBUG`.

## Test plan
- [ ] Merge and check the next workflow run's "Generate images" step for the include/skip lines.