### PR TITLE
fix: enable VERBOSE in workflow so include/skip logs render

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
         EXCLUDE_FORKS: "true"
         OWNED_ONLY: "true"
         DEBUG: "false"
+        VERBOSE: "true"
         # TODO: Remove this when they get their API working again
         # https://github.com/orgs/community/discussions/192970
         MAX_RETRIES: 5


### PR DESCRIPTION
## Root cause
`std_options.log_level` stays at `.warn` for release builds (main.zig:19-22), so the `std.log.info` lines I added in #19 were silently filtered. The workflow had `DEBUG: "false"` and no `VERBOSE`, leaving `log_level` at the compile-time default.

## Fix
Set `VERBOSE: "true"` in the workflow. `Args.verbose` maps to `log_level = .info` at main.zig:181-182, which is exactly the level the include/skip lines are logged at.

## Test plan
- [ ] Merge and re-run. Workflow log's "Generate images" step should show `include …` / `  skip  … — OWNED_ONLY` lines for each repo.